### PR TITLE
Retargeting .NET 4.8 and NET Core 3.1

### DIFF
--- a/tools/ConsoleRunner/App.config
+++ b/tools/ConsoleRunner/App.config
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2"/>
-  </startup>
-</configuration>

--- a/tools/ConsoleRunner/ConsoleRunner.csproj
+++ b/tools/ConsoleRunner/ConsoleRunner.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net48;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/tools/ConsoleRunner/Program.Config.cs
+++ b/tools/ConsoleRunner/Program.Config.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Configuration;
 using System.IO;
 using System.Runtime.Serialization;
 using Configuration = ConsoleRunner.Model.Configuration;
@@ -25,11 +24,11 @@ namespace ConsoleRunner
         {
             if (!string.IsNullOrWhiteSpace(Config.PhoneBookPath) && !File.Exists(Config.PhoneBookPath))
             {
-                throw new ConfigurationErrorsException("The phonebook has not been configured, or does not exist.");
+                throw new NotSupportedException("The phonebook has not been configured, or does not exist.");
             }
             else if (string.IsNullOrWhiteSpace(Config.EntryName))
             {
-                throw new ConfigurationErrorsException("The entry name has not been configured.");
+                throw new NotSupportedException("The entry name has not been configured.");
             }
         }
     }


### PR DESCRIPTION
Just targeting the console runner tool to the later frameworks. It was still using NET 4.7.2